### PR TITLE
ERD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/datajoint/datajoint-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/datajoint/datajoint-python?branch=master)
 [![Join the chat at https://gitter.im/datajoint/datajoint-python](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datajoint/datajoint-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PyPI version](https://badge.fury.io/py/datajoint.svg)](http://badge.fury.io/py/datajoint)
+[![Requirements Status](https://requires.io/github/datajoint/datajoint-python/requirements.svg?branch=master)](https://requires.io/github/datajoint/datajoint-python/requirements/?branch=master)
 
 # Welcome to DataJoint for Python!
 The Python version of DataJoint is undergoing major revamping to match the features and capabilities of its more mature MATLAB counterpart. We expect to complete the revamp within a few weeks: August -- September, 2015.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/eywalker/datajoint-python.svg?branch=master)](https://travis-ci.org/eywalker/datajoint-python)
 [![Coverage Status](https://coveralls.io/repos/datajoint/datajoint-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/datajoint/datajoint-python?branch=master)
 [![Join the chat at https://gitter.im/datajoint/datajoint-python](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datajoint/datajoint-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![PyPI version](https://badge.fury.io/py/datajoint.svg)](http://badge.fury.io/py/datajoint)
 
 # Welcome to DataJoint for Python!
 The Python version of DataJoint is undergoing major revamping to match the features and capabilities of its more mature MATLAB counterpart. We expect to complete the revamp within a few weeks: August -- September, 2015.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![Build Status](https://travis-ci.org/eywalker/datajoint-python.svg?branch=master)](https://travis-ci.org/eywalker/datajoint-python)
 [![Coverage Status](https://coveralls.io/repos/datajoint/datajoint-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/datajoint/datajoint-python?branch=master)
-[![Join the chat at https://gitter.im/datajoint/datajoint-python](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datajoint/datajoint-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PyPI version](https://badge.fury.io/py/datajoint.svg)](http://badge.fury.io/py/datajoint)
 [![Requirements Status](https://requires.io/github/datajoint/datajoint-python/requirements.svg?branch=master)](https://requires.io/github/datajoint/datajoint-python/requirements/?branch=master)
+[![Documentation Status](https://readthedocs.org/projects/datajoint-python/badge/?version=latest)](https://readthedocs.org/projects/datajoint-python/?badge=latest)
+[![Join the chat at https://gitter.im/datajoint/datajoint-python](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datajoint/datajoint-python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # Welcome to DataJoint for Python!
 The Python version of DataJoint is undergoing major revamping to match the features and capabilities of its more mature MATLAB counterpart. We expect to complete the revamp within a few weeks: August -- September, 2015.

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -69,7 +69,7 @@ class AutoPopulate(metaclass=abc.ABCMeta):
         jobs = self.connection.jobs[self.target.database]
         table_name = self.target.table_name
         unpopulated = (self.populated_from - self.target) & restriction
-        for key in unpopulated.project():
+        for key in unpopulated.fetch.keys():
             if not reserve_jobs or jobs.reserve(table_name, key):
                 self.connection.start_transaction()
                 if key in self.target:  # already populated

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -53,7 +53,6 @@ class Connection:
     """
 
     def __init__(self, host, user, passwd, init_fun=None):
-        self.erm = ERM(self)
         if ':' in host:
             host, port = host.split(':')
             port = int(port)
@@ -68,6 +67,7 @@ class Connection:
         self._conn.autocommit(True)
         self._in_transaction = False
         self.jobs = JobManager(self)
+        self.erm = ERM(self)
 
     def __del__(self):
         logger.info('Disconnecting {user}@{host}:{port}'.format(**self.conn_info))
@@ -80,6 +80,9 @@ class Connection:
         connected = "connected" if self.is_connected else "disconnected"
         return "DataJoint connection ({connected}) {user}@{host}:{port}".format(
             connected=connected, **self.conn_info)
+
+    def erd(self, *args, **kwargs):
+        return self.erm.copy_graph(*args, **kwargs)
 
     @property
     def is_connected(self):

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -6,7 +6,6 @@ This module hosts the Connection class that manages the connection to the mysql 
 from contextlib import contextmanager
 import pymysql
 import logging
-from collections import defaultdict
 from . import config
 from . import DataJointError
 from .erd import ERM

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -15,127 +15,6 @@ from .utils import to_camel_case
 
 logger = logging.getLogger(__name__)
 
-
-class ERM:
-    """
-    Entity Relation Map
-
-    Represents known relation between tables
-    """
-    # _checked_dependencies = set()
-
-    def __init__(self, conn):
-        self._conn = conn
-        self._parents = dict()
-        self._referenced = dict()
-        self._children = defaultdict(list)
-        self._references = defaultdict(list)
-
-    def load_dependencies(self, full_table_name):
-        # check if already loaded.  Use clear_dependencies before reloading
-        if full_table_name in self._parents:
-            return
-        self._parents[full_table_name] = list()
-        self._referenced[full_table_name] = list()
-
-        # fetch the CREATE TABLE statement
-        cur = self._conn.query('SHOW CREATE TABLE %s' % full_table_name)
-        create_statement = cur.fetchone()
-        if not create_statement:
-            raise DataJointError('Could not load the definition for %s' % full_table_name)
-        create_statement = create_statement[1].split('\n')
-
-        # build foreign key fk_parser
-        database = full_table_name.split('.')[0].strip('`')
-        add_database = lambda string, loc, toc: ['`{database}`.`{table}`'.format(database=database, table=toc[0])]
-
-        # primary key parser
-        pk_parser = pp.CaselessLiteral('PRIMARY KEY')
-        pk_parser += pp.QuotedString('(', endQuoteChar=')').setResultsName('primary_key')
-
-        # foreign key parser
-        fk_parser = pp.CaselessLiteral('CONSTRAINT').suppress()
-        fk_parser += pp.QuotedString('`').suppress()
-        fk_parser += pp.CaselessLiteral('FOREIGN KEY').suppress()
-        fk_parser += pp.QuotedString('(', endQuoteChar=')').setResultsName('attributes')
-        fk_parser += pp.CaselessLiteral('REFERENCES')
-        fk_parser += pp.Or([
-            pp.QuotedString('`').setParseAction(add_database),
-            pp.Combine(pp.QuotedString('`', unquoteResults=False) +
-                       '.' + pp.QuotedString('`', unquoteResults=False))
-            ]).setResultsName('referenced_table')
-        fk_parser += pp.QuotedString('(', endQuoteChar=')').setResultsName('referenced_attributes')
-
-        # parse foreign keys
-        primary_key = None
-        for line in create_statement:
-            if primary_key is None:
-                try:
-                    result = pk_parser.parseString(line)
-                except pp.ParseException:
-                    pass
-                else:
-                    primary_key = [s.strip(' `') for s in result.primary_key.split(',')]
-            try:
-                result = fk_parser.parseString(line)
-            except pp.ParseException:
-                pass
-            else:
-                if not primary_key:
-                    raise DataJointError('No primary key found %s' % full_table_name)
-                if result.referenced_attributes != result.attributes:
-                    raise DataJointError(
-                        "%s's foreign key refers to differently named attributes in %s"
-                        % (self.__class__.__name__, result.referenced_table))
-                if all(q in primary_key for q in [s.strip('` ') for s in result.attributes.split(',')]):
-                    self._parents[full_table_name].append(result.referenced_table)
-                    self._children[result.referenced_table].append(full_table_name)
-                else:
-                    self._referenced[full_table_name].append(result.referenced_table)
-                    self._references[result.referenced_table].append(full_table_name)
-
-    def clear_dependencies(self, full_table_name):
-        for ref in self._parents.pop(full_table_name, []):
-            if full_table_name in self._children[ref]:
-                self._children[ref].remove(full_table_name)
-        for ref in self._referenced.pop(full_table_name, []):
-            if full_table_name in self._references[ref]:
-                self._references[ref].remove(full_table_name)
-
-    @property
-    def parents(self):
-        return self._parents
-
-    @property
-    def children(self):
-        return self._children
-
-    @property
-    def references(self):
-        return self._references
-
-    @property
-    def referenced(self):
-        return self._referenced
-
-    def get_descendants(self, full_table_name):
-        """
-        :param full_table_name: a table name in the format `database`.`table_name`
-        :return: list of all children and references, in order of dependence.
-        This is helpful for cascading delete or drop operations.
-        """
-        ret = defaultdict(lambda: 0)
-
-        def recurse(full_table_name, level):
-            if level > ret[full_table_name]:
-                ret[full_table_name] = level
-            for child in self.children[full_table_name] + self.references[full_table_name]:
-                recurse(child, level+1)
-
-        recurse(full_table_name, 0)
-        return sorted(ret.keys(), key=ret.__getitem__)
-
-
 class RelGraph(DiGraph):
     """
     A directed graph representing relations between tables within and across
@@ -214,7 +93,8 @@ class RelGraph(DiGraph):
         ax.axis('off')  # hide axis
 
     def __repr__(self):
-        pass
+        #TODO: provide string version of ERD
+        return "RelGraph: to be implemented"
 
     def restrict_by_modules(self, modules, fill=False):
         """
@@ -238,11 +118,11 @@ class RelGraph(DiGraph):
         """
         nodes = [n for n in self.nodes() if self.node[n].get('label') in tables]
         if fill:
-            nodes =  self.fill_connection_nodes(nodes)
+            nodes = self.fill_connection_nodes(nodes)
         return self.subgraph(nodes)
 
     def restrict_by_tables_in_module(self, module, tables, fill=False):
-        nodes = [n for n in self.nodes() if self.node[n].get('mod') and \
+        nodes = [n for n in self.nodes() if self.node[n].get('mod') in module and
                  self.node[n].get('cls') in tables]
         if fill:
             nodes =  self.fill_connection_nodes(nodes)
@@ -307,7 +187,7 @@ class RelGraph(DiGraph):
             s.update(self.descendants(c))
         return s
 
-    def up_down_neighbors(self, node, ups, downs, prev=None):
+    def up_down_neighbors(self, node, ups=2, downs=2, _prev=None):
         """
         Returns a set of all nodes that can be reached from the specified node by
         moving up and down the ancestry tree with specific number of ups and downs.
@@ -326,26 +206,26 @@ class RelGraph(DiGraph):
         :param node: node to base all discovery on
         :param ups: number of times to go up the ancestry tree (go up to parent)
         :param downs: number of times to go down the ancestry tree (go down to children)
-        :param prev: previously visited node. This will be excluded from up down search in this recursion
+        :param _prev: previously visited node. This will be excluded from up down search in this recursion
         :return: a set of all nodes that can be reached within specified numbers of ups and downs from the source node
         """
         s = {node}
         if ups > 0:
             for x in self.predecessors_iter(node):
-                if x == prev:
+                if x == _prev:
                     continue
                 s.update(self.up_down_neighbors(x, ups-1, downs, node))
         if downs > 0:
             for x in self.successors_iter(node):
-                if x == prev:
+                if x == _prev:
                     continue
                 s.update(self.up_down_neighbors(x, ups, downs-1, node))
         return s
 
-    def n_neighbors(self, node, n, prev=None):
+    def n_neighbors(self, node, n, directed=False, prev=None):
         """
         Returns a set of n degree neighbors for the
-        specified node. The set with contain the node itself.
+        specified node. The set will contain the node itself.
 
         n degree neighbors are defined as node that can be reached
         within n edges from the root node.
@@ -360,85 +240,169 @@ class RelGraph(DiGraph):
             s.update(self.predecessors(node))
             s.update(self.successors(node))
             return s
-        for x in self.predecesors_iter():
-            if x == prev:  # skip prev point
-                continue
-            s.update(self.n_neighbors(x, n-1, prev))
+        if not directed:
+            for x in self.predecesors_iter():
+                if x == prev:  # skip prev point
+                    continue
+                s.update(self.n_neighbors(x, n-1, prev))
         for x in self.succesors_iter():
             if x == prev:
                 continue
             s.update(self.n_neighbors(x, n-1, prev))
         return s
 
-
-
-class DBConnGraph(RelGraph):
+class ERM(RelGraph):
     """
-    Represents relational structure of the databases and tables associated with a connection object
+    Entity Relation Map
+
+    Represents known relation between tables
     """
+    # _checked_dependencies = set()
+
     def __init__(self, conn, *args, **kwargs):
-        """
-        Initializes graph associated with a connection object
-        :param conn: connection object for which the relational graph is to be constructed
-        """
-        # this is calling the networkx.DiGraph initializer
         super().__init__(*args, **kwargs)
+        self._conn = conn
+        self._parents = dict()
+        self._referenced = dict()
+        self._children = defaultdict(list)
+        self._references = defaultdict(list)
         if conn.is_connected:
             self._conn = conn
         else:
             raise DataJointError('The connection is broken') #TODO: make better exception message
         self.update_graph()
 
-    def full_table_to_class(self, full_table_name):
-        """
-        Converts full table reference of form `database`.`table` into the corresponding
-        module_name.class_name format. For the module name, only the actual name of the module is used, with
-        all of its package reference removed.
-        :param full_table_name: full name of the table in the form `database`.`table`
-        :return: name in the form of module_name.class_name if corresponding module and class exists
-        """
-        full_table_ptrn = re.compile(r'`(.*)`\.`(.*)`')
-        m = full_table_ptrn.match(full_table_name)
-        dbname = m.group(1)
-        table_name = m.group(2)
-        mod_name = self._conn.db_to_mod[dbname]
-        mod_name = mod_name.split('.')[-1]
-        class_name = to_camel_case(table_name)
-        return '{}.{}'.format(mod_name, class_name)
-
     def update_graph(self, reload=False):
-        """
-        Update the connection graph. Set reload=True to cause the connection object's
-        table heading information to be reloaded as well
-        """
-        if reload:
-            self._conn.load_headings(force=True)
-
         self.clear()
 
         # create primary key foreign connections
-        for table, parents in self._conn.parents.items():
-            label = self.full_table_to_class(table)
-            mod, cls = label.split('.')
+        for table, parents in self._parents.items():
+            mod, cls = (x.strip('`') for x in table.split('.'))
 
-            self.add_node(table, label=label,
-                          mod=mod, cls=cls)
+            self.add_node(table, label=table,
+                         mod=mod, cls=cls)
             for parent in parents:
                 self.add_edge(parent, table, rel='parent')
 
         # create non primary key foreign connections
-        for table, referenced in self._conn.referenced.items():
+        for table, referenced in self._referenced.items():
             for ref in referenced:
                 self.add_edge(ref, table, rel='referenced')
 
-    def copy_graph(self):
+    def copy_graph(self, *args, **kwargs):
         """
         Return copy of the graph represented by this object at the
         time of call. Note that the returned graph is no longer
         bound to a connection.
         """
-        return RelGraph(self)
+        return RelGraph(self, *args, **kwargs)
 
     def subgraph(self, *args, **kwargs):
         return RelGraph(self).subgraph(*args, **kwargs)
+
+    def load_dependencies(self, full_table_name):
+        # check if already loaded.  Use clear_dependencies before reloading
+        if full_table_name in self._parents:
+            return
+        self._parents[full_table_name] = list()
+        self._referenced[full_table_name] = list()
+
+        # fetch the CREATE TABLE statement
+        cur = self._conn.query('SHOW CREATE TABLE %s' % full_table_name)
+        create_statement = cur.fetchone()
+        if not create_statement:
+            raise DataJointError('Could not load the definition for %s' % full_table_name)
+        create_statement = create_statement[1].split('\n')
+
+        # build foreign key fk_parser
+        database = full_table_name.split('.')[0].strip('`')
+        add_database = lambda string, loc, toc: ['`{database}`.`{table}`'.format(database=database, table=toc[0])]
+
+        # primary key parser
+        pk_parser = pp.CaselessLiteral('PRIMARY KEY')
+        pk_parser += pp.QuotedString('(', endQuoteChar=')').setResultsName('primary_key')
+
+        # foreign key parser
+        fk_parser = pp.CaselessLiteral('CONSTRAINT').suppress()
+        fk_parser += pp.QuotedString('`').suppress()
+        fk_parser += pp.CaselessLiteral('FOREIGN KEY').suppress()
+        fk_parser += pp.QuotedString('(', endQuoteChar=')').setResultsName('attributes')
+        fk_parser += pp.CaselessLiteral('REFERENCES')
+        fk_parser += pp.Or([
+            pp.QuotedString('`').setParseAction(add_database),
+            pp.Combine(pp.QuotedString('`', unquoteResults=False) +
+                       '.' + pp.QuotedString('`', unquoteResults=False))
+            ]).setResultsName('referenced_table')
+        fk_parser += pp.QuotedString('(', endQuoteChar=')').setResultsName('referenced_attributes')
+
+        # parse foreign keys
+        primary_key = None
+        for line in create_statement:
+            if primary_key is None:
+                try:
+                    result = pk_parser.parseString(line)
+                except pp.ParseException:
+                    pass
+                else:
+                    primary_key = [s.strip(' `') for s in result.primary_key.split(',')]
+            try:
+                result = fk_parser.parseString(line)
+            except pp.ParseException:
+                pass
+            else:
+                if not primary_key:
+                    raise DataJointError('No primary key found %s' % full_table_name)
+                if result.referenced_attributes != result.attributes:
+                    raise DataJointError(
+                        "%s's foreign key refers to differently named attributes in %s"
+                        % (self.__class__.__name__, result.referenced_table))
+                if all(q in primary_key for q in [s.strip('` ') for s in result.attributes.split(',')]):
+                    self._parents[full_table_name].append(result.referenced_table)
+                    self._children[result.referenced_table].append(full_table_name)
+                else:
+                    self._referenced[full_table_name].append(result.referenced_table)
+                    self._references[result.referenced_table].append(full_table_name)
+
+        self.update_graph()
+
+    def clear_dependencies(self, full_table_name):
+        for ref in self._parents.pop(full_table_name, []):
+            if full_table_name in self._children[ref]:
+                self._children[ref].remove(full_table_name)
+        for ref in self._referenced.pop(full_table_name, []):
+            if full_table_name in self._references[ref]:
+                self._references[ref].remove(full_table_name)
+
+    @property
+    def parents(self):
+        return self._parents
+
+    @property
+    def children(self):
+        return self._children
+
+    @property
+    def references(self):
+        return self._references
+
+    @property
+    def referenced(self):
+        return self._referenced
+
+    def get_descendants(self, full_table_name):
+        """
+        :param full_table_name: a table name in the format `database`.`table_name`
+        :return: list of all children and references, in order of dependence.
+        This is helpful for cascading delete or drop operations.
+        """
+        ret = defaultdict(lambda: 0)
+
+        def recurse(full_table_name, level):
+            if level > ret[full_table_name]:
+                ret[full_table_name] = level
+            for child in self.children[full_table_name] + self.references[full_table_name]:
+                recurse(child, level+1)
+
+        recurse(full_table_name, 0)
+        return sorted(ret.keys(), key=ret.__getitem__)
 

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -174,11 +174,13 @@ class Fetch:
         repr_string += ' '.join(['+' + '-' * (width - 2) + '+' for _ in columns]) + '\n'
         for tup in rel.fetch(limit=limit):
             repr_string += ' '.join([template % column for column in tup]) + '\n'
-        if len(self._relation) > limit:
+        if len(rel) > limit:
             repr_string += '...\n'
-        repr_string += ' (%d tuples)\n' % len(self._relation)
+        repr_string += ' (%d tuples)\n' % len(rel)
         return repr_string
 
+    def __len__(self):
+        return len(self._relation)
 
 class Fetch1:
     def __init__(self, relation):

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -1,0 +1,205 @@
+from collections import OrderedDict
+from .blob import unpack
+import numpy as np
+from datajoint import DataJointError
+from . import key as PRIMARY_KEY
+
+def prepare_attributes(relation, item):
+    if isinstance(item, str) or item is PRIMARY_KEY:
+        item = (item,)
+    elif isinstance(item, int):
+        item = (relation.heading.names[item],)
+    elif isinstance(item, slice):
+        attributes = relation.heading.names
+        start = attributes.index(item.start) if isinstance(item.start, str) else item.start
+        stop = attributes.index(item.stop) if isinstance(item.stop, str) else item.stop
+        item = attributes[slice(start, stop, item.step)]
+    try:
+        attributes = tuple(i for i in item if i is not PRIMARY_KEY)
+    except TypeError:
+        raise DataJointError("Index must be a slice, a tuple, a list, a string.")
+    return item, attributes
+
+class FetchQuery:
+
+    def __init__(self, relation):
+        """
+
+        """
+        self.behavior = dict(
+            offset=0, limit=None, order_by=None, descending=False, as_dict=False, map=None
+        )
+        self._relation = relation
+
+
+    def from_to(self, fro, to):
+        self.behavior['offset'] = fro
+        self.behavior['limit'] = to - fro
+        return self
+
+    def order_by(self, order_by):
+        self.behavior['order_by'] = order_by
+        return self
+
+    def as_dict(self):
+        self.behavior['as_dict'] = True
+
+    def ascending(self):
+        self.behavior['descending'] = False
+        return self
+
+    def descending(self):
+        self.behavior['descending'] = True
+        return self
+
+    def apply(self, f):
+        self.behavior['map'] = f
+        return self
+
+    def limit_by(self, limit):
+        self.behavior['limit'] = limit
+        return self
+
+    def set_behavior(self, **kwargs):
+        self.behavior.update(kwargs)
+        return self
+
+    def __call__(self, **kwargs):
+        """
+        Fetches the relation from the database table into an np.array and unpacks blob attributes.
+
+        :param offset: the number of tuples to skip in the returned result
+        :param limit: the maximum number of tuples to return
+        :param order_by: the list of attributes to order the results. No ordering should be assumed if order_by=None.
+        :param descending: the list of attributes to order the results
+        :param as_dict: returns a list of dictionaries instead of a record array
+        :return: the contents of the relation in the form of a structured numpy.array
+
+        """
+        behavior = dict(self.behavior, **kwargs)
+
+        cur = self._relation.cursor(offset=behavior['offset'], limit=behavior['limit'],
+                                    order_by=behavior['order_by'], descending=behavior['descending'],
+                                    as_dict=behavior['as_dict'])
+
+        heading = self._relation.heading
+        if behavior['as_dict']:
+            ret = [OrderedDict((name, unpack(d[name]) if heading[name].is_blob else d[name])
+                               for name in heading.names)
+                   for d in cur.fetchall()]
+        else:
+            ret = np.array(list(cur.fetchall()), dtype=heading.as_dtype)
+            for blob_name in heading.blobs:
+                ret[blob_name] = list(map(unpack, ret[blob_name]))
+
+        if behavior['map'] is not None:
+            f = behavior['map']
+            for i in range(len(ret)):
+                ret[i] = f(ret[i])
+
+        return ret
+
+    def __iter__(self):
+        """
+        Iterator that returns the contents of the database.
+        """
+        behavior = self.behavior
+
+        cur = self._relation.cursor(offset=behavior['offset'], limit=behavior['limit'],
+                                    order_by=behavior['order_by'], descending=behavior['descending'],
+                                    as_dict=behavior['as_dict'])
+
+        heading = self._relation.heading
+        do_unpack = tuple(h in heading.blobs for h in heading.names)
+        values = cur.fetchone()
+        while values:
+            if behavior['as_dict']:
+                yield OrderedDict(
+                    (field_name, unpack(values[field_name])) if up
+                    else (field_name, values[field_name])
+                    for field_name, up in zip(heading.names, do_unpack))
+            else:
+                yield tuple(unpack(value) if up else value for up, value in zip(do_unpack, values))
+            values = cur.fetchone()
+
+    def keys(self, **kwargs):
+        """
+        Iterator that returns primary keys.
+        """
+        if 'as_dict' not in kwargs:
+            kwargs['as_dict'] = True
+        yield from self._relation.project().fetch.set_behavior(**kwargs)
+
+
+    def __getitem__(self, item):
+        """
+        Fetch attributes as separate outputs.
+        datajoint.key is a special value that requests the entire primary key
+        :return: tuple with an entry for each element of item
+
+        Examples:
+        a, b = relation['a', 'b']
+        a, b, key = relation['a', 'b', datajoint.key]
+        results = relation['a':'z']    # return attributes a-z as a tuple
+        results = relation[:-1]   # return all but the last attribute
+        """
+        single_output = isinstance(item, str) or item is PRIMARY_KEY or isinstance(item, int)
+        item, attributes = prepare_attributes(self._relation, item)
+
+        result = self._relation.project(*attributes).fetch()
+        return_values = [
+            np.ndarray(result.shape,
+                       np.dtype({name: result.dtype.fields[name] for name in self._relation.primary_key}),
+                       result, 0, result.strides)
+            if attribute is PRIMARY_KEY
+            else result[attribute]
+            for attribute in item
+            ]
+        return return_values[0] if single_output else return_values
+
+
+class Fetch1Query:
+
+    def __init__(self, relation):
+        self._relation = relation
+
+    def __call__(self):
+        """
+        This version of fetch is called when self is expected to contain exactly one tuple.
+        :return: the one tuple in the relation in the form of a dict
+        """
+        heading = self._relation.heading
+
+        cur = self._relation.cursor(as_dict=True)
+        ret = cur.fetchone()
+        if not ret or cur.fetchone():
+            raise DataJointError('fetch1 should only be used for relations with exactly one tuple')
+
+        return OrderedDict((name, unpack(ret[name]) if heading[name].is_blob else ret[name])
+                           for name in heading.names)
+
+    def __getitem__(self, item):
+        """
+        Fetch attributes as separate outputs.
+        datajoint.key is a special value that requests the entire primary key
+        :return: tuple with an entry for each element of item
+
+        Examples:
+        a, b = relation['a', 'b']
+        a, b, key = relation['a', 'b', datajoint.key]
+        results = relation['a':'z']    # return attributes a-z as a tuple
+        results = relation[:-1]   # return all but the last attribute
+        """
+        single_output = isinstance(item, str) or item is PRIMARY_KEY or isinstance(item, int)
+        item, attributes = prepare_attributes(self._relation, item)
+
+        result = self._relation.project(*attributes).fetch()
+        return_values = tuple(
+            np.ndarray(result.shape,
+                       np.dtype({name: result.dtype.fields[name] for name in self._relation.primary_key}),
+                       result, 0, result.strides)
+            if attribute is PRIMARY_KEY
+            else result[attribute][0]
+            for attribute in item
+        )
+        return return_values[0] if single_output else return_values

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -56,9 +56,10 @@ class Fetch:
     def order_by(self, *args):
         if len(args) > 0:
             self.behavior['order_by'] = self.behavior['order_by'] if self.behavior['order_by'] is not None else []
+            namepat = re.compile(r"\s*(?P<name>\w+).*")
             for a in args: # remove duplicates
-                name = a.split('=')[0].strip()
-                pat = re.compile(r"%s\s*(=\s*(DESC|ASC)\s*|)?$" % (name,), re.I)
+                name = namepat.match(a).group('name')
+                pat = re.compile(r"%s(\s*$|\s+(\S*\s*)*$)" % (name,))
                 self.behavior['order_by'] = [e for e in self.behavior['order_by'] if not pat.match(e)]
             self.behavior['order_by'].extend(args)
         return self

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -55,20 +55,13 @@ class Fetch:
     @copy_first
     def order_by(self, *args):
         if len(args) > 0:
-            self.behavior['order_by'] = self.behavior['order_by'] if self.behavior['order_by'] is not None else []
-            namepat = re.compile(r"\s*(?P<name>\w+).*")
-            for a in args: # remove duplicates
-                name = namepat.match(a).group('name')
-                pat = re.compile(r"%s(\s*$|\s+(\S*\s*)*$)" % (name,))
-                self.behavior['order_by'] = [e for e in self.behavior['order_by'] if not pat.match(e)]
-            self.behavior['order_by'].extend(args)
+            self.behavior['order_by'] = args
         return self
 
     @copy_first
     def as_dict(self):
         self.behavior['as_dict'] = True
         return self
-
 
     @copy_first
     def limit_to(self, limit):

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -8,6 +8,7 @@ import numpy as np
 from datajoint import DataJointError
 from . import key as PRIMARY_KEY
 from collections import abc
+from . import config
 
 
 def prepare_attributes(relation, item):
@@ -35,7 +36,9 @@ def copy_first(f):
 
     return ret
 
+
 class Fetch:
+
     def __init__(self, relation):
         if isinstance(relation, Fetch): # copy constructor
             self.behavior = dict(relation.behavior)
@@ -45,7 +48,6 @@ class Fetch:
                 offset=None, limit=None, order_by=None, as_dict=False
             )
             self._relation = relation
-
 
     @copy_first
     def order_by(self, *args):
@@ -161,6 +163,21 @@ class Fetch:
             for attribute in item
             ]
         return return_values[0] if single_output else return_values
+
+    def __repr__(self):
+        limit = config['display.limit']
+        width = config['display.width']
+        rel = self._relation.project(*self._relation.heading.non_blobs)  # project out blobs
+        template = '%%-%d.%ds' % (width, width)
+        columns = rel.heading.names
+        repr_string = ' '.join([template % column for column in columns]) + '\n'
+        repr_string += ' '.join(['+' + '-' * (width - 2) + '+' for _ in columns]) + '\n'
+        for tup in rel.fetch(limit=limit):
+            repr_string += ' '.join([template % column for column in tup]) + '\n'
+        if len(self._relation) > limit:
+            repr_string += '...\n'
+        repr_string += ' (%d tuples)\n' % len(self._relation)
+        return repr_string
 
 
 class Fetch1:

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -250,7 +250,7 @@ class Heading:
 
         return Heading(attribute_list)
 
-    def __add__(self, other):
+    def join(self, other, left):
         """
         join two headings
         """
@@ -258,7 +258,10 @@ class Heading:
         attribute_list = [v._asdict() for v in self.attributes.values()]
         for name in other.names:
             if name not in self.names:
-                attribute_list.append(other.attributes[name]._asdict())
+                attribute = other.attributes[name]._asdict();
+                if left:
+                    attribute['in_key'] = False
+                attribute_list.append(attribute)
         return Heading(attribute_list)
 
     def resolve(self):

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -72,6 +72,10 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         """
         return self.full_table_name
 
+    @property
+    def select_fields(self):
+        return '*'
+
     # ------------- dependencies ---------- #
     @property
     def parents(self):

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -75,6 +75,11 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
     def select_fields(self):
         return '*'
 
+    def erd(self, *args, **kwargs):
+        erd = self.connection.erd()
+        nodes = erd.up_down_neighbors(self.full_table_name)
+        return erd.restrict_by_tables(nodes)
+
     # ------------- dependencies ---------- #
     @property
     def parents(self):

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -107,7 +107,7 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         return [relation for relation in relations if relation.is_declared]
 
     def _repr_helper(self):
-        return self.full_table_name
+        return "%s.%s()" % (self.__module__, self.__class__.__name__)
 
     # --------- SQL functionality --------- #
     @property

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -285,6 +285,9 @@ class FreeRelation(Relation):
         self._definition = definition
         self._context = context
 
+    def __repr__(self):
+        return "FreeRelation(`%s`.`%s`)" % (self.database, self._table_name)
+
     @property
     def definition(self):
         return self._definition

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -264,7 +264,7 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         return ret['Data_length'] + ret['Index_length']
 
     # --------- functionality used by the decorator ---------
-    def prepare(self):
+    def _prepare(self):
         """
         This method is overridden by the user_relations subclasses. It is called on an instance
         once when the class is declared.

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -106,6 +106,9 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
                      for table in self.connection.erm.get_descendants(self.full_table_name))
         return [relation for relation in relations if relation.is_declared]
 
+    def _repr_helper(self):
+        return self.full_table_name
+
     # --------- SQL functionality --------- #
     @property
     def is_declared(self):

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -181,18 +181,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             raise DataJointError('limit is required when offset is set')
         sql = self.make_select()
         if order_by is not None:
-            order_attr, order = [], []
-            for a in order_by:
-                a = [e.strip() for e in a.split('=')]
-                if len(a) == 1:
-                    order_attr.append(a[0])
-                    order.append('ASC')
-                else:
-                    order_attr.append(a[0])
-                    order.append(a[1])
-
-            sql += ' ORDER BY ' + ', '.join(['`%s` %s' % (attr, val) for attr, val in
-                                            zip(order_attr, order)])
+            sql += ' ORDER BY ' + ', '.join(order_by)
 
         if limit is not None:
             sql += ' LIMIT %d' % limit

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -141,6 +141,8 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         """
         number of tuples in the relation.  This also takes care of the truth value
         """
+        if self._grouped:
+            return len(Subquery(self))
         cur = self.connection.query(self.make_select('count(*)'))
         return cur.fetchone()[0]
 

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -152,12 +152,6 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         """
         return len(self & item) > 0
 
-    def __call__(self, *args, **kwargs):
-        """
-        calling a relation is equivalent to fetching from it
-        """
-        return self.fetch(*args, **kwargs)
-
     def cursor(self, offset=0, limit=None, order_by=None, descending=False, as_dict=False):
         """
         Return query cursor.

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -286,8 +286,8 @@ class RelationalOperand(metaclass=abc.ABCMeta):
                     common_attributes, "not " if negate else "",
                     common_attributes, r.from_clause, r.where_clause)
                 negate = False
-
-            assert isinstance(r, str), 'condition must be converted into a string'
+            if not isinstance(r, str):
+                raise DataJointError('Invalid restriction object')
             conditions.append('%s(%s)' % ('not ' if negate else '', r))
 
         return ' WHERE ' + ' AND '.join(conditions)
@@ -334,7 +334,6 @@ class Not:
     """
     inverse restriction
     """
-
     def __init__(self, restriction):
         self.restriction = restriction
 

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -5,14 +5,12 @@ classes for relational algebra
 import numpy as np
 import abc
 import re
-from collections import OrderedDict
 from copy import copy
 from . import config
-from . import key as PRIMARY_KEY
 from . import DataJointError
 import logging
 
-from .blob import unpack
+from .fetch import FetchQuery, Fetch1Query
 
 logger = logging.getLogger(__name__)
 
@@ -209,71 +207,11 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         return repr_string
 
     def fetch1(self):
-        """
-        This version of fetch is called when self is expected to contain exactly one tuple.
-        :return: the one tuple in the relation in the form of a dict
-        """
-        heading = self.heading
-        cur = self.cursor(as_dict=True)
-        ret = cur.fetchone()
-        if not ret or cur.fetchone():
-            raise DataJointError('fetch1 should only be used for relations with exactly one tuple')
-        return OrderedDict((name, unpack(ret[name]) if heading[name].is_blob else ret[name])
-                           for name in self.heading.names)
+        return Fetch1Query(self)
 
-    def fetch(self, offset=0, limit=None, order_by=None, descending=False, as_dict=False):
-        """
-        fetches the relation from the database table into an np.array and unpacks blob attributes.
-        :param offset: the number of tuples to skip in the returned result
-        :param limit: the maximum number of tuples to return
-        :param order_by: the list of attributes to order the results. No ordering should be assumed if order_by=None.
-        :param descending: the list of attributes to order the results
-        :param as_dict: returns a list of dictionaries instead of a record array
-        :return: the contents of the relation in the form of a structured numpy.array
-        """
-        cur = self.cursor(offset=offset, limit=limit, order_by=order_by,
-                          descending=descending, as_dict=as_dict)
-        heading = self.heading
-        if as_dict:
-            ret = [OrderedDict((name, unpack(d[name]) if heading[name].is_blob else d[name])
-                               for name in self.heading.names)
-                   for d in cur.fetchall()]
-        else:
-            ret = np.array(list(cur.fetchall()), dtype=heading.as_dtype)
-            for blob_name in heading.blobs:
-                ret[blob_name] = list(map(unpack, ret[blob_name]))
-        return ret
-
-    def values(self, offset=0, limit=None, order_by=None, descending=False, as_dict=False):
-        """
-        Iterator that returns the contents of the database.
-        """
-        cur = self.cursor(offset=offset, limit=limit, order_by=order_by,
-                          descending=descending, as_dict=as_dict)
-        heading = self.heading
-        do_unpack = tuple(h in heading.blobs for h in heading.names)
-        values = cur.fetchone()
-        while values:
-            if as_dict:
-                yield OrderedDict(
-                    (field_name, unpack(values[field_name])) if up
-                    else (field_name, values[field_name])
-                    for field_name, up in zip(heading.names, do_unpack))
-            else:
-                yield tuple(unpack(value) if up else value for up, value in zip(do_unpack, values))
-            values = cur.fetchone()
-
-    def __iter__(self):
-        """
-        Iterator that yields individual tuples of the current table dictionaries.
-        """
-        yield from self.values(as_dict=True)
-
-    def keys(self, *args, **kwargs):
-        """
-        Iterator that returns primary keys.
-        """
-        yield from self.project().values(*args, **kwargs)
+    @property
+    def fetch(self):
+        return FetchQuery(self)
 
     @property
     def where_clause(self):
@@ -314,42 +252,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
 
         return ' WHERE ' + ' AND '.join(condition_string)
 
-    def __getitem__(self, item):
-        """
-        Fetch attributes as separate outputs.
-        datajoint.key is a special value that requests the entire primary key
-        :return: tuple with an entry for each element of item
 
-        Examples:
-        a, b = relation['a', 'b']
-        a, b, key = relation['a', 'b', datajoint.key]
-        results = relation['a':'z']    # return attributes a-z as a tuple
-        results = relation[:-1]   # return all but the last attribute
-        """
-        single_output = isinstance(item, str) or item is PRIMARY_KEY or isinstance(item, int)
-        if isinstance(item, str) or item is PRIMARY_KEY:
-            item = (item,)
-        elif isinstance(item, int):
-            item = (self.heading.names[item],)
-        elif isinstance(item, slice):
-            attributes = self.heading.names
-            start = attributes.index(item.start) if isinstance(item.start, str) else item.start
-            stop = attributes.index(item.stop) if isinstance(item.stop, str) else item.stop
-            item = attributes[slice(start, stop, item.step)]
-        try:
-            attributes = tuple(i for i in item if i is not PRIMARY_KEY)
-        except TypeError:
-            raise DataJointError("Index must be a slice, a tuple, a list, a string.")
-        result = self.project(*attributes).fetch()
-        return_values = [
-            np.ndarray(result.shape,
-                       np.dtype({name: result.dtype.fields[name] for name in self.primary_key}),
-                       result, 0, result.strides)
-            if attribute is PRIMARY_KEY
-            else result[attribute]
-            for attribute in item
-            ]
-        return return_values[0] if single_output else return_values
 
 
 class Not:

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -115,7 +115,10 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             return self
         ret = copy(self)
         ret._restrictions = list(ret.restrictions)  # copy restriction list
-        ret._restrictions.append(restriction)
+        if isinstance(restriction, list):
+            ret._restricitons.extend(restriction)
+        else:
+            ret._restrictions.append(restriction)
         return ret
 
     def __sub__(self, restriction):

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -408,12 +408,11 @@ class Projection(RelationalOperand):
                 self._renamed_attributes.update({d['alias']: d['sql_expression']})
             else:
                 self._attributes.append(attribute)
-        if group:
+        if group is not None:
             if arg.connection != group.connection:
                 raise DataJointError('Cannot join relations with different database connections')
-            # TODO: don't Subquery if not necessary (if does not have some types of restrictions)
-            self._group = Subquery(group)
-            self._arg = Subquery(arg)
+            self._group = group if not group.restrictions and not group.heading.computed else Subquery(group)
+            self._arg = arg
         else:
             self._group = None
             if arg.heading.computed or\

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -53,7 +53,7 @@ class schema:
         # trigger table declaration by requesting the heading from an instance
         instance = cls()
         instance.heading
-        instance.prepare()
+        instance._prepare()
         return cls
 
     @property

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -34,7 +34,7 @@ class Lookup(Relation):
         """
         return '#' + from_camel_case(self.__class__.__name__)
 
-    def prepare(self):
+    def _prepare(self):
         """
         Checks whether the instance has a property called `contents` and inserts its elements.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ networkx
 matplotlib
 sphinx_rtd_theme
 mock
+pygraphviz==1.3rc1

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -39,6 +39,26 @@ class Subject(dj.Manual):
     def prepare(self):
         self.insert(self.contents, ignore_errors=True)
 
+@schema
+class Language(dj.Lookup):
+
+    definition = """
+    # languages spoken by some of the developers
+
+    entry_id    : int
+    ---
+    name        : varchar(40) # name of the developer
+    language    : varchar(40) # language
+    """
+
+    contents = [
+            (0, 'Fabian', 'English'),
+            (1, 'Edgar', 'English'),
+            (2, 'Dimitri', 'English'),
+            (3, 'Dimitri', 'Ukrainian'),
+            (4, 'Fabian', 'German'),
+            (5, 'Edgar', 'Japanese'),
+        ]
 
 @schema
 class Experiment(dj.Imported):

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -36,7 +36,7 @@ class Subject(dj.Manual):
         [1552, '1552', 'mouse', '2015-06-15', ''],
         [1553, '1553', 'mouse', '2016-07-01', '']]
 
-    def prepare(self):
+    def _prepare(self):
         self.insert(self.contents, ignore_errors=True)
 
 @schema
@@ -45,19 +45,18 @@ class Language(dj.Lookup):
     definition = """
     # languages spoken by some of the developers
 
-    entry_id    : int
-    ---
     name        : varchar(40) # name of the developer
     language    : varchar(40) # language
+    ---
     """
 
     contents = [
-            (0, 'Fabian', 'English'),
-            (1, 'Edgar', 'English'),
-            (2, 'Dimitri', 'English'),
-            (3, 'Dimitri', 'Ukrainian'),
-            (4, 'Fabian', 'German'),
-            (5, 'Edgar', 'Japanese'),
+            ('Fabian', 'English'),
+            ('Edgar', 'English'),
+            ('Dimitri', 'English'),
+            ('Dimitri', 'Ukrainian'),
+            ('Fabian', 'German'),
+            ('Edgar', 'Japanese'),
         ]
 
 @schema

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,121 @@
+from operator import itemgetter, attrgetter
+import itertools
+from nose.tools import assert_true
+from numpy.testing import assert_array_equal, assert_equal
+import numpy as np
+
+from . import schema
+import datajoint as dj
+
+
+class TestFetch:
+    def __init__(self):
+        self.subject = schema.Subject()
+        self.lang = schema.Language()
+
+    def test_getitem(self):
+        """Testing Fetch.__getitem__"""
+
+        np.testing.assert_array_equal(sorted(self.subject.project().fetch(), key=itemgetter(0)),
+                                      sorted(self.subject.fetch[dj.key], key=itemgetter(0)),
+                                      'Primary key is not returned correctly')
+
+        tmp = self.subject.fetch(order_by=['subject_id'])
+
+        for column, field in zip(self.subject.fetch[:], [e[0] for e in tmp.dtype.descr]):
+            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
+
+        subject_notes, key, real_id = self.subject.fetch['subject_notes', dj.key, 'real_id']
+        #
+        np.testing.assert_array_equal(sorted(subject_notes), sorted(tmp['subject_notes']))
+        np.testing.assert_array_equal(sorted(real_id), sorted(tmp['real_id']))
+        np.testing.assert_array_equal(sorted(key, key=itemgetter(0)),
+                                      sorted(self.subject.project().fetch(), key=itemgetter(0)))
+
+        for column, field in zip(self.subject.fetch['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
+            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
+
+    def test_order_by(self):
+        """Tests order_by sorting order"""
+        langs = schema.Language.contents
+
+        for ord_name, ord_lang in itertools.product(*2 * [['ASC', 'DESC']]):
+            cur = self.lang.fetch.order_by('name=' + ord_name, 'language=' + ord_lang)()
+            langs.sort(key=itemgetter(2), reverse=ord_lang == 'DESC')
+            langs.sort(key=itemgetter(1), reverse=ord_name == 'DESC')
+            for c, l in zip(cur, langs):
+                assert_true(np.all(cc == ll for cc, ll in zip(c, l)), 'Sorting order is different')
+
+    def test_order_by_default(self):
+        """Tests order_by sorting order with defaults"""
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.order_by('language', 'name=DESC')()
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+
+        for c, l in zip(cur, langs):
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_order_by_direct(self):
+        """Tests order_by sorting order passing it to __call__"""
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch(order_by=['language', 'name=DESC'])
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        for c, l in zip(cur, langs):
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_limit_to(self):
+        """Test the limit_to function """
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name=DESC'])
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        assert_equal(len(cur), 4, 'Length is not correct')
+        for c, l in list(zip(cur, langs))[:4]:
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_from_to(self):
+        """Test the from_to function """
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name=DESC'])
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        assert_equal(len(cur), 4, 'Length is not correct')
+        for c, l in list(zip(cur, langs[2:6])):
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_iter(self):
+        """Test iterator"""
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.order_by('language', 'name=DESC')
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        for (_, name, lang), (_, tname, tlang) in list(zip(cur, langs)):
+            assert_true(name == tname and lang == tlang, 'Values are not the same')
+
+    def test_keys(self):
+        """test key iterator"""
+        langs = schema.Language.contents
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+
+        cur = self.lang.fetch.order_by('language', 'name=DESC')['entry_id']
+        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name=DESC').keys()]
+
+        keys, _, _ = list(zip(*langs))
+        for k, c, c2 in zip(keys, cur, cur2):
+            assert_true(k == c == c2, 'Values are not the same')
+
+    def test_fetch1(self):
+        key = {'entry_id': 0}
+        true = schema.Language.contents[0]
+
+        dat = (self.lang & key).fetch1()
+        for k, (ke, c) in zip(true, dat.items()):
+            assert_true(k == c == (self.lang & key).fetch1[ke], 'Values are not the same')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -71,7 +71,7 @@ class TestFetch:
         """Test the limit_to function """
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name DESC'])
+        cur = self.lang.fetch.limit(4)(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
@@ -82,7 +82,7 @@ class TestFetch:
         """Test the from_to function """
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name DESC'])
+        cur = self.lang.fetch(offset=2, limit=4, order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -125,3 +125,11 @@ class TestFetch:
         f2 = f.order_by('name')
         assert_true(f.behavior['order_by'] is None and len(f2.behavior['order_by']) == 1, 'Object was not copied')
 
+    def test_repr(self):
+        """Test string representation of fetch, returning table preview"""
+        repr = self.subject.fetch.__repr__()
+        n = len(repr.strip().split('\n'))
+        limit = dj.config['display.limit']
+        # 3 lines are used for headers (2) and summary statement (1)
+        assert_true(n - 3 <= limit)
+

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -41,8 +41,8 @@ class TestFetch:
 
         for ord_name, ord_lang in itertools.product(*2 * [['ASC', 'DESC']]):
             cur = self.lang.fetch.order_by('name ' + ord_name, 'language ' + ord_lang)()
-            langs.sort(key=itemgetter(2), reverse=ord_lang == 'DESC')
-            langs.sort(key=itemgetter(1), reverse=ord_name == 'DESC')
+            langs.sort(key=itemgetter(1), reverse=ord_lang == 'DESC')
+            langs.sort(key=itemgetter(0), reverse=ord_name == 'DESC')
             for c, l in zip(cur, langs):
                 assert_true(np.all(cc == ll for cc, ll in zip(c, l)), 'Sorting order is different')
 
@@ -51,8 +51,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.order_by('language', 'name DESC')()
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
 
         for c, l in zip(cur, langs):
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
@@ -62,8 +62,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch(order_by=['language', 'name DESC'])
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
         for c, l in zip(cur, langs):
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
 
@@ -72,8 +72,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name DESC'])
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
         for c, l in list(zip(cur, langs))[:4]:
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
@@ -83,8 +83,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name DESC'])
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
         for c, l in list(zip(cur, langs[2:6])):
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
@@ -94,27 +94,26 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.order_by('language', 'name DESC')
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
-        for (_, name, lang), (_, tname, tlang) in list(zip(cur, langs)):
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
+        for (name, lang), (tname, tlang) in list(zip(cur, langs)):
             assert_true(name == tname and lang == tlang, 'Values are not the same')
 
     def test_keys(self):
         """test key iterator"""
         langs = schema.Language.contents
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
 
-        cur = self.lang.fetch.order_by('language', 'name DESC')['entry_id']
-        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name DESC').keys()]
+        cur = self.lang.fetch.order_by('language', 'name DESC')['name','language']
+        cur2 = list(self.lang.fetch.order_by('language', 'name DESC').keys())
 
-        keys, _, _ = list(zip(*langs))
-        for k, c, c2 in zip(keys, cur, cur2):
-            assert_true(k == c == c2, 'Values are not the same')
+        for c, c2 in zip(zip(*cur), cur2):
+            assert_true(c == tuple(c2.values()), 'Values are not the same')
 
     def test_fetch1(self):
-        key = {'entry_id': 0}
-        true = schema.Language.contents[0]
+        key = {'name': 'Edgar', 'language':'Japanese'}
+        true = schema.Language.contents[-1]
 
         dat = (self.lang & key).fetch1()
         for k, (ke, c) in zip(true, dat.items()):
@@ -126,8 +125,3 @@ class TestFetch:
         f2 = f.order_by('name')
         assert_true(f.behavior['order_by'] is None and len(f2.behavior['order_by']) == 1, 'Object was not copied')
 
-    def test_overwrite(self):
-        """Test whether order_by overwrites duplicates"""
-        f = self.lang.fetch.order_by('name    DeSc ')
-        f2 = f.order_by('name')
-        assert_true(f2.behavior['order_by'] == ['name'], 'order_by attribute was not overwritten')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -119,3 +119,15 @@ class TestFetch:
         dat = (self.lang & key).fetch1()
         for k, (ke, c) in zip(true, dat.items()):
             assert_true(k == c == (self.lang & key).fetch1[ke], 'Values are not the same')
+
+    def test_copy(self):
+        """Test whether modifications copy the object"""
+        f = self.lang.fetch
+        f2 = f.order_by('name')
+        assert_true(f.behavior['order_by'] is None and len(f2.behavior['order_by']) == 1, 'Object was not copied')
+
+    def test_overwrite(self):
+        """Test whether order_by overwrites duplicates"""
+        f = self.lang.fetch.order_by('name =   DeSc ')
+        f2 = f.order_by('name')
+        assert_true(f2.behavior['order_by'] == ['name'], 'order_by attribute was not overwritten')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -40,7 +40,7 @@ class TestFetch:
         langs = schema.Language.contents
 
         for ord_name, ord_lang in itertools.product(*2 * [['ASC', 'DESC']]):
-            cur = self.lang.fetch.order_by('name=' + ord_name, 'language=' + ord_lang)()
+            cur = self.lang.fetch.order_by('name ' + ord_name, 'language ' + ord_lang)()
             langs.sort(key=itemgetter(2), reverse=ord_lang == 'DESC')
             langs.sort(key=itemgetter(1), reverse=ord_name == 'DESC')
             for c, l in zip(cur, langs):
@@ -50,7 +50,7 @@ class TestFetch:
         """Tests order_by sorting order with defaults"""
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.order_by('language', 'name=DESC')()
+        cur = self.lang.fetch.order_by('language', 'name DESC')()
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
 
@@ -61,7 +61,7 @@ class TestFetch:
         """Tests order_by sorting order passing it to __call__"""
         langs = schema.Language.contents
 
-        cur = self.lang.fetch(order_by=['language', 'name=DESC'])
+        cur = self.lang.fetch(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         for c, l in zip(cur, langs):
@@ -71,7 +71,7 @@ class TestFetch:
         """Test the limit_to function """
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name=DESC'])
+        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
@@ -82,7 +82,7 @@ class TestFetch:
         """Test the from_to function """
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name=DESC'])
+        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
@@ -93,7 +93,7 @@ class TestFetch:
         """Test iterator"""
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.order_by('language', 'name=DESC')
+        cur = self.lang.fetch.order_by('language', 'name DESC')
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         for (_, name, lang), (_, tname, tlang) in list(zip(cur, langs)):
@@ -105,8 +105,8 @@ class TestFetch:
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
 
-        cur = self.lang.fetch.order_by('language', 'name=DESC')['entry_id']
-        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name=DESC').keys()]
+        cur = self.lang.fetch.order_by('language', 'name DESC')['entry_id']
+        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name DESC').keys()]
 
         keys, _, _ = list(zip(*langs))
         for k, c, c2 in zip(keys, cur, cur2):
@@ -128,6 +128,6 @@ class TestFetch:
 
     def test_overwrite(self):
         """Test whether order_by overwrites duplicates"""
-        f = self.lang.fetch.order_by('name =   DeSc ')
+        f = self.lang.fetch.order_by('name    DeSc ')
         f2 = f.order_by('name')
         assert_true(f2.behavior['order_by'] == ['name'], 'order_by attribute was not overwritten')

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -61,20 +61,20 @@ class TestRelationalOperand:
         """Testing RelationalOperand.__getitem__"""
 
         np.testing.assert_array_equal(sorted(self.subject.project().fetch(), key=itemgetter(0)),
-                                      sorted(self.subject[dj.key], key=itemgetter(0)),
+                                      sorted(self.subject.fetch[dj.key], key=itemgetter(0)),
                                       'Primary key is not returned correctly')
 
         tmp = self.subject.fetch(order_by=['subject_id'])
 
-        for column, field in zip(self.subject[:], [e[0] for e in tmp.dtype.descr]):
+        for column, field in zip(self.subject.fetch[:], [e[0] for e in tmp.dtype.descr]):
             np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
 
-        subject_notes, key, real_id = self.subject['subject_notes', dj.key, 'real_id']
-
+        subject_notes, key, real_id = self.subject.fetch['subject_notes', dj.key, 'real_id']
+        #
         np.testing.assert_array_equal(sorted(subject_notes), sorted(tmp['subject_notes']))
         np.testing.assert_array_equal(sorted(real_id), sorted(tmp['real_id']))
         np.testing.assert_array_equal(sorted(key, key=itemgetter(0)),
                                       sorted(self.subject.project().fetch(), key=itemgetter(0)))
 
-        for column, field in zip(self.subject['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
+        for column, field in zip(self.subject.fetch['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
             np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -53,28 +53,3 @@ import datajoint as dj
 #     def test_not(self):
 #         pass
 
-class TestRelationalOperand:
-    def __init__(self):
-        self.subject = schema.Subject()
-
-    def test_getitem(self):
-        """Testing RelationalOperand.__getitem__"""
-
-        np.testing.assert_array_equal(sorted(self.subject.project().fetch(), key=itemgetter(0)),
-                                      sorted(self.subject.fetch[dj.key], key=itemgetter(0)),
-                                      'Primary key is not returned correctly')
-
-        tmp = self.subject.fetch(order_by=['subject_id'])
-
-        for column, field in zip(self.subject.fetch[:], [e[0] for e in tmp.dtype.descr]):
-            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
-
-        subject_notes, key, real_id = self.subject.fetch['subject_notes', dj.key, 'real_id']
-        #
-        np.testing.assert_array_equal(sorted(subject_notes), sorted(tmp['subject_notes']))
-        np.testing.assert_array_equal(sorted(real_id), sorted(tmp['real_id']))
-        np.testing.assert_array_equal(sorted(key, key=itemgetter(0)),
-                                      sorted(self.subject.project().fetch(), key=itemgetter(0)))
-
-        for column, field in zip(self.subject.fetch['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
-            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')


### PR DESCRIPTION
First pass implementation of ERD is provided. You can access the plot by either

``` python
dj.conn().erd().plot()
```

or

``` python
rel.erd().plot()
```

ERD on a base relation plots all parent and children nodes that can be reached within two ups and downs. ERD on connection plots all currently loaded tables.

This is a _first pass_ implementation and thus the interface is expected to enhanced significantly. Be aware of a very specific requirement added `pygraphviz==1.3rc1`.
