### PR TITLE
ERD implmentation

### DIFF
--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -8,6 +8,7 @@ import pymysql as client
 import logging
 from . import config
 from . import DataJointError
+from datajoint.erd import ERD
 from .dependencies import Dependencies
 from .jobs import JobManager
 
@@ -93,7 +94,8 @@ class Connection:
         return self._conn.ping()
 
     def erd(self):
-        return self.dependencies.erd()
+        self.dependencies.load()
+        return ERD.create_from_dependencies(self.dependencies)
 
     def query(self, query, args=(), as_dict=False):
         """

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import pyparsing as pp
-from .erd import ERD
 from . import DataJointError
 
 
@@ -17,10 +16,6 @@ class Dependencies:
         self._referenced = dict()
         self._children = defaultdict(list)
         self._references = defaultdict(list)
-
-    def erd(self):
-        self.load()
-        return ERD.create_from_dependencies(self)
 
     @property
     def parents(self):

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -406,6 +406,9 @@ class ERD(DiGraph):
         tables
         :return: string representation of the erm
         """
+        if len(self) == 0:
+            return "No relations to show"
+
         paths = self.longest_paths()
 
         # turn comparator into Key object for use in sort

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -43,13 +43,9 @@ def parse_base_relations(rels):
     name_map = {}
     for r in rels:
         try:
-            module = r.__module__
-            parts = []
-            if module != '__main__':
-                parts.append(module.split('.')[-1])
-            parts.append(r.__name__)
-            name_map[r().full_table_name] = '.'.join(parts)
-        except:
+            name_map[r().full_table_name] = '{module}.{cls}'.format(module=r.__module__, cls=r.__name__)
+        except TypeError:
+            # skip if failed to instantiate BaseRelation derivative
             pass
     return name_map
 


### PR DESCRIPTION
ERD is implemented via command line interface, displaying full path to the BaseRelation derivative class in place of the full table name when found.
