### PR TITLE
unicode patch-in-progress

### DIFF
--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -93,7 +93,7 @@ class Connection:
             warnings.filterwarnings('ignore', '.*deprecated.*')
             self._conn = client.connect(init_command=self.init_fun,
                                         sql_mode="NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
-                                                 "STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION",
+                                                 "STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION", charset="utf8",
                                         **self.conn_info)
 
     def register(self, schema):

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -176,7 +176,7 @@ def declare(full_table_name, definition, context):
                        ['PRIMARY KEY (`' + '`,`'.join(primary_key) + '`)'] +
                        foreign_key_sql +
                        index_sql) +
-            '\n) ENGINE=InnoDB, CHARACTER SET latin1, COMMENT "%s"' % table_comment), uses_external
+            '\n) ENGINE=InnoDB, COMMENT "%s"' % table_comment), uses_external
 
 
 def compile_attribute(line, in_key, foreign_key_sql):


### PR DESCRIPTION
Hi Dimitri -

Per our discussion, these are the changes used to support unicode on the installation using it.
To note, the connection character set is hardcoded to be UTF8 and should probably instead be blank with a conditional splicing in of a user value if present.