### PR TITLE
Provide WIN10/Python3.7/MySQL 5.7 compatibility

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -112,21 +112,23 @@ def setup_package():
     dj.config['safemode'] = False
 
     # Add old MySQL
-    source = os.path.dirname(os.path.realpath(__file__)) + \
-        "/external-legacy-data"
+    source = Path(
+        os.path.dirname(os.path.realpath(__file__)),
+        'external-legacy-data')
     db_name = "djtest_blob_migrate"
     db_file = "v0_11.sql"
     conn_root.query("""
         CREATE DATABASE IF NOT EXISTS {};
         """.format(db_name))
 
-    statements = parse_sql('{}/{}'.format(source, db_file))
+    statements = parse_sql(Path(source,db_file))
     for s in statements:
         conn_root.query(s)
 
     # Add old S3
-    source = os.path.dirname(os.path.realpath(__file__)) + \
-        "/external-legacy-data/s3"
+    source = Path(
+        os.path.dirname(os.path.realpath(__file__)),
+        'external-legacy-data','s3')
     bucket = "migrate-test"
     region = "us-east-1"
     try:
@@ -138,10 +140,9 @@ def setup_package():
     for path in pathlist:
         if os.path.isfile(str(path)) and ".sql" not in str(path):
             minioClient.fput_object(
-                    bucket, os.path.relpath(
-                        str(path),
-                        '{}/{}'.format(source, bucket)
-                        ), str(path))
+                    bucket, str(Path(
+                        os.path.relpath(path,Path(source,bucket)))
+                                .as_posix()), str(path))
     # Add S3
     try:
         minioClient.make_bucket("datajoint-test", location=region)
@@ -151,9 +152,9 @@ def setup_package():
     # Add old File Content
     try:
         shutil.copytree(
-                os.path.dirname(os.path.realpath(__file__)) +
-                "/external-legacy-data/file/temp",
-                os.path.expanduser('~/temp'))
+                Path(os.path.dirname(os.path.realpath(__file__)),
+                'external-legacy-data','file','temp'),
+                Path(os.path.expanduser('~'),'temp'))
     except FileExistsError:
         pass
 
@@ -189,4 +190,4 @@ def teardown_package():
     minioClient.remove_bucket(bucket)
 
     # Remove old File Content
-    shutil.rmtree(os.path.expanduser('~/temp'))
+    shutil.rmtree(Path(os.path.expanduser('~'),'temp'))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -172,7 +172,8 @@ def teardown_package():
     for db in cur.fetchall():
         conn.query('DROP DATABASE `{}`'.format(db[0]))
     conn.query('SET FOREIGN_KEY_CHECKS=1')
-    remove("dj_local_conf.json")
+    if os.path.exists("dj_local_conf.json"):
+        remove("dj_local_conf.json")
 
     # Remove old S3
     bucket = "migrate-test"

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -264,7 +264,7 @@ class SigIntTable(dj.Computed):
     """
 
     def _make_tuples(self, key):
-        os.kill(os.getpid(), signal.SIGINT)
+        raise KeyboardInterrupt
 
 
 @schema
@@ -274,7 +274,7 @@ class SigTermTable(dj.Computed):
     """
 
     def make(self, key):
-        os.kill(os.getpid(), signal.SIGTERM)
+        raise SystemExit('SIGTERM received')
 
 
 @schema

--- a/tests/test_blob_migrate.py
+++ b/tests/test_blob_migrate.py
@@ -3,6 +3,7 @@ from nose.tools import assert_true, assert_false, assert_equal, \
 
 import datajoint as dj
 import os
+from pathlib import Path
 import re
 from . import S3_CONN_INFO
 from . import CONN_INFO
@@ -35,9 +36,9 @@ class TestBlobMigrate:
                 secret_key=S3_CONN_INFO['secret_key']),
             'local': dict(
                 protocol='file',
-                location=os.path.expanduser('~/temp/migrate-test'))
+                location=str(Path(os.path.expanduser('~'),'temp','migrate-test')))
         }
-        dj.config['cache'] = os.path.expanduser('~/temp/dj-cache')
+        dj.config['cache'] = str(Path(os.path.expanduser('~'),'temp','dj-cache'))
 
         LEGACY_HASH_SIZE = 43
 
@@ -100,14 +101,14 @@ class TestBlobMigrate:
 
             contents_hash_function = {
                 'file': lambda ext, relative_path: dj.hash.uuid_from_file(
-                    os.path.join(ext.spec['location'], relative_path)),
+                    str(Path(ext.spec['location'], relative_path))),
                 's3': lambda ext, relative_path: dj.hash.uuid_from_buffer(
                     ext.s3.get(relative_path))
             }
 
             for _hash, size in zip(*legacy_external.fetch('hash', 'size')):
                 if _hash in hashes:
-                    relative_path = os.path.join(schema.database, _hash)
+                    relative_path = str(Path(schema.database, _hash).as_posix())
                     uuid = dj.hash.uuid_from_buffer(init_string=relative_path)
                     external_path = ext._make_external_filepath(relative_path)
                     if ext.spec['protocol'] == 's3':
@@ -198,9 +199,9 @@ class TestBlobMigrate:
                 secret_key=S3_CONN_INFO['secret_key']),
             'local': dict(
                 protocol='file',
-                location=os.path.expanduser('~/temp/migrate-test'))
+                location=str(Path(os.path.expanduser('~'),'temp','migrate-test')))
         }
-        dj.config['cache'] = os.path.expanduser('~/temp/dj-cache')
+        dj.config['cache'] = str(Path(os.path.expanduser('~'),'temp','dj-cache'))
 
         test_mod = dj.create_virtual_module('test_mod', 'djtest_blob_migrate')
         r = test_mod.A.fetch('blob_share', order_by='id')

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,7 +5,6 @@ from datajoint.jobs import ERROR_MESSAGE_LENGTH, TRUNCATION_APPENDIX
 import random
 import string
 
-
 subjects = schema.Subject()
 
 
@@ -45,7 +44,6 @@ def test_reserve_job():
     assert_false(schema.schema.jobs,
                  'failed to clear error jobs')
 
-
 def test_restrictions():
     # clear out jobs table
     jobs = schema.schema.jobs
@@ -62,7 +60,6 @@ def test_restrictions():
                 'There should be only one entries with error status in table a')
     jobs.delete()
 
-
 def test_sigint():
     # clear out job table
     schema.schema.jobs.delete()
@@ -76,7 +73,6 @@ def test_sigint():
     assert_equals(error_message, 'KeyboardInterrupt')
     schema.schema.jobs.delete()
 
-
 def test_sigterm():
     # clear out job table
     schema.schema.jobs.delete()
@@ -89,7 +85,6 @@ def test_sigterm():
     assert_equals(status, 'error')
     assert_equals(error_message, 'SystemExit: SIGTERM received')
     schema.schema.jobs.delete()
-
 
 def test_long_error_message():
     # clear out jobs table


### PR DESCRIPTION
Specifically
- `test_blob_migrate`
- `KeyboardInterrupt` and `SystemExit` Exceptions
- Utilize `pathlib` in setup and teardown for `nosetests`