### PR TITLE
tests/{schema,test_jobs}.py: add tests/test_jobs.py:test_suppress_dj_errors

### DIFF
--- a/tests/schema.py
+++ b/tests/schema.py
@@ -278,6 +278,38 @@ class SigTermTable(dj.Computed):
 
 
 @schema
+class DjExceptionNames(dj.Lookup):
+    definition = """
+    dj_exception_name:    char(64)
+    """
+    @property
+    def contents(self):
+        ret = []
+        for e in dir(dj.errors):
+            ea = getattr(dj.errors, e) 
+            if callable(ea):
+                try:
+                    werks = (isinstance(ea, type(Exception))
+                             and isinstance(ea(), Exception))
+                except TypeError as te:
+                    pass
+                if werks:
+                    ret.append((e,))
+        return ret
+
+
+@schema
+class ErrorClassTable(dj.Computed):
+    definition = """
+    -> DjExceptionNames
+    """
+    def make(self, key):
+        ename = key['dj_exception_name']
+        raise getattr(dj.errors, ename)(ename)
+
+
+
+@schema
 class DecimalPrimaryKey(dj.Lookup):
     definition = """
     id  :  decimal(4,3)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -88,6 +88,18 @@ def test_sigterm():
     assert_equals(error_message, 'SystemExit: SIGTERM received')
     schema.schema.jobs.delete()
 
+
+def test_suppress_dj_errors():
+    ''' test_suppress_dj_errors: dj errors suppressable w/o native py blobs'''
+    schema.schema.jobs.delete()
+    with dj.config(enable_python_native_blobs=False):
+        schema.ErrorClassTable().populate(
+            reserve_jobs=True, suppress_errors=True)
+
+        assert len(schema.DjExceptionNames()) == len(schema.DjExceptionNames
+                                                     & schema.schema.jobs)
+
+
 def test_long_error_message():
     # clear out jobs table
     schema.schema.jobs.delete()


### PR DESCRIPTION

+ supporting tables: ErrorClassTable and DjExceptionNames

added to test for #700: jobs table requires `enable_python_native_blobs`;
additionally has utility to ensure suppress_errors can trap all DJ exceptions.

populate of ErrorClassTable raises 1 DjExceptionName() per DjExceptionNames
which should sucessfullly result in jobs table being filled with
len(DjExceptionNames) records.