### PR TITLE
Fix error when cascading delete on tables with many, complex keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ notebook
 __main__.py
 jupyter_custom.js
 apk_requirements.txt
+.eggs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release notes
 
-### 0.13.0 -- Mar 19, 2021
+### 0.13.0 -- Mar 24, 2021
 * Re-implement query transpilation into SQL, fixing issues (#386, #449, #450, #484). PR #754
 * Re-implement cascading deletes for better performance. PR #839.
 * Add table method `.update1` to update a row in the table with new values PR #763
@@ -11,6 +11,7 @@
 * Default enable_python_native_blobs to True
 * Bugfix - Regression error on joins with same attribute name (#857) PR #878
 * Bugfix - Error when `fetch1('KEY')` when `dj.config['fetch_format']='frame'` set (#876) PR #880, #878
+* Bugfix - Error when cascading deletes in tables with many, complex keys (#883, #886) PR #839
 * Drop support for Python 3.5
 
 ### 0.12.8 -- Jan 12, 2021

--- a/LNX-docker-compose.yml
+++ b/LNX-docker-compose.yml
@@ -32,7 +32,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.0.15
+    image: datajoint/nginx:v0.0.16
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.13.dev6"
+__version__ = "0.13.dev7"
 
 assert len(__version__) <= 10  # The log table limits version to the 10 characters

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,4 +1,4 @@
-0.13.0 -- Mar 19, 2021
+0.13.0 -- Mar 24, 2021
 ----------------------
 * Re-implement query transpilation into SQL, fixing issues (#386, #449, #450, #484). PR #754
 * Re-implement cascading deletes for better performance. PR #839.
@@ -10,6 +10,7 @@
 * Default enable_python_native_blobs to True
 * Bugfix - Regression error on joins with same attribute name (#857) PR #878
 * Bugfix - Error when `fetch1('KEY')` when `dj.config['fetch_format']='frame'` set (#876) PR #880, #878
+* Bugfix - Error when cascading deletes in tables with many, complex keys (#883, #886) PR #839
 * Drop support for Python 3.5
 
 0.12.8 -- Jan 12, 2021

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -34,7 +34,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.0.15
+    image: datajoint/nginx:v0.0.16
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -366,3 +366,16 @@ class Child(dj.Lookup):
     name: varchar(30)
     """
     contents = [(1, 12, 'Dan')]
+
+# Related to issue #886 (8), #883 (5)
+@schema
+class ComplexParent(dj.Lookup):
+    definition = '\n'.join(['parent_id_{}: int'.format(i+1) for i in range(8)])
+    contents = [tuple(i for i in range(8))]
+
+
+@schema
+class ComplexChild(dj.Lookup):
+    definition = '\n'.join(['-> ComplexParent'] + ['child_id_{}: int'.format(i+1)
+                                                   for i in range(1)])
+    contents = [tuple(i for i in range(9))]


### PR DESCRIPTION
Related to datajoint/datajoint-python#839

This PR serves to resolve issues when there are many complex keys between a parent/child relationship that result in MySQL truncating the error message (now utilized by cascading deletes on account of performance).

The solution takes the following approach:
- Try to match all info from error message using the full regex.
- If successful, proceed.
- Otherwise, attempt a partial match extracting only the info necessary to determine the specific constraint.
- Make an additional query to `INFORMATION_SCHEMA` to determine the appropriate `fk_attrs` and `pr_attrs`.
- Update reverse proxy image.

Fix datajoint/datajoint-python#883
Fix datajoint/datajoint-python#886