### PR TITLE
Fix renaming attributes

### DIFF
--- a/LNX-docker-compose.yml
+++ b/LNX-docker-compose.yml
@@ -32,7 +32,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.0.18
+    image: datajoint/nginx:v0.0.19
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -11,7 +11,7 @@ from .attribute_adapter import get_adapter
 
 UUID_DATA_TYPE = 'binary(16)'
 MAX_TABLE_NAME_LENGTH = 64
-CONSTANT_LITERALS = {'CURRENT_TIMESTAMP'}  # SQL literals to be used without quotes (case insensitive)
+CONSTANT_LITERALS = {'CURRENT_TIMESTAMP', 'NULL'}  # SQL literals to be used without quotes (case insensitive)
 EXTERNAL_TABLE_ROOT = '~external'
 
 TYPE_PATTERN = {k: re.compile(v, re.I) for k, v in dict(

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -9,6 +9,7 @@ from .fetch import Fetch, Fetch1
 from .preview import preview, repr_html
 from .condition import AndList, Not, \
     make_condition, assert_join_compatibility, extract_column_names, PromiscuousOperand
+from .declare import CONSTANT_LITERALS
 
 logger = logging.getLogger(__name__)
 
@@ -313,9 +314,9 @@ class QueryExpression:
         Each attribute name can only be used once.
         """
         # new attributes in parentheses are included again with the new name without removing original
-        duplication_pattern = re.compile(r'\s*\(\s*(?P<name>\w*[a-z]+\w*)\s*\)\s*$')
+        duplication_pattern = re.compile(fr'^\s*\(\s*(?!{"|".join(CONSTANT_LITERALS)})(?P<name>[a-zA-Z_]+\w*)\s*\)\s*$')
         # attributes without parentheses renamed
-        rename_pattern = re.compile(r'\s*(?P<name>\w*[a-z]+\w*)\s*$')
+        rename_pattern = re.compile(fr'^\s*(?!{"|".join(CONSTANT_LITERALS)})(?P<name>[a-zA-Z_]+\w*)\s*$')
         replicate_map = {k: m.group('name')
                          for k, m in ((k, duplication_pattern.match(v)) for k, v in named_attributes.items()) if m}
         rename_map = {k: m.group('name')

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -313,7 +313,7 @@ class QueryExpression:
         Each attribute name can only be used once.
         """
         # new attributes in parentheses are included again with the new name without removing original
-        duplication_pattern = re.compile(r'\s*\(\s*(?P<name>\w*[a-z]+\w*)\s*$\)\s*$')
+        duplication_pattern = re.compile(r'\s*\(\s*(?P<name>\w*[a-z]+\w*)\s*\)\s*$')
         # attributes without parentheses renamed
         rename_pattern = re.compile(r'\s*(?P<name>\w*[a-z]+\w*)\s*$')
         replicate_map = {k: m.group('name')

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -313,9 +313,9 @@ class QueryExpression:
         Each attribute name can only be used once.
         """
         # new attributes in parentheses are included again with the new name without removing original
-        duplication_pattern = re.compile(r'\s*\(\s*(?P<name>[a-z][a-z_0-9]*)\s*\)\s*$')
+        duplication_pattern = re.compile(r'\s*\(\s*(?P<name>\w*[a-z]+\w*)\s*$\)\s*$')
         # attributes without parentheses renamed
-        rename_pattern = re.compile(r'\s*(?P<name>[a-z][a-z_0-9]*)\s*$')
+        rename_pattern = re.compile(r'\s*(?P<name>\w*[a-z]+\w*)\s*$')
         replicate_map = {k: m.group('name')
                          for k, m in ((k, duplication_pattern.match(v)) for k, v in named_attributes.items()) if m}
         rename_map = {k: m.group('name')

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -314,9 +314,9 @@ class QueryExpression:
         Each attribute name can only be used once.
         """
         # new attributes in parentheses are included again with the new name without removing original
-        duplication_pattern = re.compile(fr'^\s*\(\s*(?!{"|".join(CONSTANT_LITERALS)})(?P<name>[a-zA-Z_]+\w*)\s*\)\s*$')
+        duplication_pattern = re.compile(fr'^\s*\(\s*(?!{"|".join(CONSTANT_LITERALS)})(?P<name>[a-zA-Z_]\w*)\s*\)\s*$')
         # attributes without parentheses renamed
-        rename_pattern = re.compile(fr'^\s*(?!{"|".join(CONSTANT_LITERALS)})(?P<name>[a-zA-Z_]+\w*)\s*$')
+        rename_pattern = re.compile(fr'^\s*(?!{"|".join(CONSTANT_LITERALS)})(?P<name>[a-zA-Z_]\w*)\s*$')
         replicate_map = {k: m.group('name')
                          for k, m in ((k, duplication_pattern.match(v)) for k, v in named_attributes.items()) if m}
         rename_map = {k: m.group('name')

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -34,7 +34,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.0.18
+    image: datajoint/nginx:v0.0.19
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -15,8 +15,6 @@ from .schema import (Experiment, TTest3, Trial, Ephys, Child, Parent, SubjectA, 
 
 from . import PREFIX, CONN_INFO
 
-from time import sleep
-
 
 def setup():
     """

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -13,6 +13,10 @@ from .schema_simple import (A, B, D, E, F, L, DataA, DataB, TTestUpdate, IJ, JI,
 from .schema import (Experiment, TTest3, Trial, Ephys, Child, Parent, SubjectA, SessionA,
                      SessionStatusA, SessionDateA)
 
+from . import PREFIX, CONN_INFO
+
+from time import sleep
+
 
 def setup():
     """
@@ -176,6 +180,15 @@ class TestRelational:
                      'failed semijoin or antijoin')
         assert_equal(len((D() & cond).proj()), len((D() & cond)),
                      'projection failed: altered its argument''s cardinality')
+
+    @staticmethod
+    def test_rename_non_dj_attribute():
+        schema = PREFIX + '_test1'
+        connection = dj.conn(**CONN_INFO)
+        connection.query(f'CREATE TABLE {schema}.test_table (oldID int PRIMARY KEY)').fetchall()
+        mySchema = dj.VirtualModule(schema, schema)
+        assert 'oldID' not in  mySchema.TestTable.proj(new_name='oldID').heading.attributes.keys(), 'Failed to rename attribute correctly'
+        connection.query(f'DROP TABLE {schema}.test_table')
 
     @staticmethod
     def test_union():


### PR DESCRIPTION
Hey, I fixed the regex for projection to exclude SQL variables such as `NONE` and `CURRENT_TIMESTAMP`. Your original fix allowed non DataJoint variables to be projected as intended, but also allowed these SQL variables to match.

Related to #972