### PR TITLE
Fix parsing SQL files

### DIFF
--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -146,3 +146,5 @@ def parse_sql(filepath):
                     if line.endswith(delimiter):
                         yield " ".join(statement)
                         statement = []
+        if statement:
+            yield " ".join(statement)


### PR DESCRIPTION
## Summary
- fix parse_sql to yield final statement if file lacks trailing delimiter

## Testing
- `pytest -k test_something_that_does_not_exist -q` *(fails: ModuleNotFoundError: No module named 'pymysql')*


------
https://chatgpt.com/codex/tasks/task_e_6866df889e1483208e47ae80f143b24b