### PR TITLE
Add tests for parse_sql

### DIFF
--- a/tests/test_utils_parse_sql.py
+++ b/tests/test_utils_parse_sql.py
@@ -1,0 +1,34 @@
+import pytest
+
+from datajoint.utils import parse_sql
+
+
+def test_parse_sql_with_trailing_delimiter(tmp_path):
+    sql_file = tmp_path / "script.sql"
+    sql_file.write_text(
+        """
+        -- comment should be ignored
+        CREATE TABLE t (id INT);
+        INSERT INTO t VALUES (1);
+        """
+    )
+    statements = list(parse_sql(sql_file))
+    assert statements == [
+        "CREATE TABLE t (id INT);",
+        "INSERT INTO t VALUES (1);",
+    ]
+
+
+def test_parse_sql_without_trailing_delimiter(tmp_path):
+    sql_file = tmp_path / "script.sql"
+    sql_file.write_text(
+        """
+        CREATE TABLE t (id INT);
+        INSERT INTO t VALUES (1)
+        """
+    )
+    statements = list(parse_sql(sql_file))
+    assert statements == [
+        "CREATE TABLE t (id INT);",
+        "INSERT INTO t VALUES (1)",
+    ]


### PR DESCRIPTION
## Summary
- add new test verifying parse_sql behaviour with trailing delimiter
- add new test verifying parse_sql behaviour without trailing delimiter

## Testing
- `pytest -q tests/test_utils_parse_sql.py` *(fails: ModuleNotFoundError: No module named 'certifi')*

------
https://chatgpt.com/codex/tasks/task_e_6866f3527570832095f5fd7e65bd7c9c