### PR TITLE
Update changelog notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release notes
 
+**Note:** This file is no longer updated. See the GitHub change log page for the
+latest release notes: <https://github.com/datajoint/datajoint-python/releases>.
+
 ### 0.14.3 -- Sep 23, 2024
 - Added - `dj.Top` restriction - PR [#1024](https://github.com/datajoint/datajoint-python/issues/1024)) PR [#1084](https://github.com/datajoint/datajoint-python/pull/1084)
 - Fixed - Added encapsulating double quotes to comply with [DOT language](https://graphviz.org/doc/info/lang.html) - PR [#1177](https://github.com/datajoint/datajoint-python/pull/1177)


### PR DESCRIPTION
## Summary
- deprecate the local CHANGELOG
- point users to GitHub releases for updates

## Testing
- `pytest tests/test_cli.py::test_cli_version -q` *(fails: ModuleNotFoundError: No module named 'certifi')*

------
https://chatgpt.com/codex/tasks/task_e_68838b6c22208320976d572ec0305158