### PR TITLE
example of dependency injection to avoid globals in init

### DIFF
--- a/src/datajoint/connection.py
+++ b/src/datajoint/connection.py
@@ -163,13 +163,19 @@ class Connection:
         password: str,
         port: int | None = None,
         use_tls: bool | dict | None = None,
+        *,
+        backend: str | None = None,
+        config_override: "Config | None" = None,
     ) -> None:
+        # Config reference - use override if provided, else global config
+        self._config = config_override if config_override is not None else config
+
         if ":" in host:
             # the port in the hostname overrides the port argument
             host, port = host.split(":")
             port = int(port)
         elif port is None:
-            port = config["database.port"]
+            port = self._config["database.port"]
         self.conn_info = dict(host=host, port=port, user=user, passwd=password)
         if use_tls is not False:
             # use_tls can be: None (auto-detect), True (enable), False (disable), or dict (custom config)
@@ -186,11 +192,9 @@ class Connection:
         self._query_cache = None
         self._is_closed = True  # Mark as closed until connect() succeeds
 
-        # Config reference - defaults to global config, but Instance sets its own
-        self._config = config
-
-        # Select adapter based on configured backend
-        backend = self._config["database.backend"]
+        # Select adapter: explicit backend > config backend
+        if backend is None:
+            backend = self._config["database.backend"]
         self.adapter = get_adapter(backend)
 
         self.connect()

--- a/src/datajoint/instance.py
+++ b/src/datajoint/instance.py
@@ -104,11 +104,16 @@ class Instance:
         if port is None:
             port = self.config.database.port
 
-        # Create connection
-        self.connection = Connection(host, user, password, port, use_tls)
-
-        # Attach config to connection so tables can access it
-        self.connection._config = self.config
+        # Create connection with this instance's config and backend
+        self.connection = Connection(
+            host,
+            user,
+            password,
+            port,
+            use_tls,
+            backend=self.config.database.backend,
+            config_override=self.config,
+        )
 
     def Schema(
         self,


### PR DESCRIPTION
This prevents global `config` from being set (and then used to get the backend adapter) in the `__init__` function. Setting it after didn't prevent the wrong backend from being used.